### PR TITLE
Improve Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We're so glad that you're thinking about contributing to moja global. We welcome your contributions!
 
-Following are some guidelines and instructions to assist you in contributing to our projects.
+Here are some guidelines and instructions for contributing to our projects. Please go through them before making a contribution.
 
 
 ## Code of Conduct
@@ -12,18 +12,18 @@ moja global governs its participants according to the Contributor Covenant [Code
 
 ## FAQ and General Questions
 
-If you have any questions then please start by going through our [FAQs](https://github.com/moja-global/.github/wiki). If your question is not answered there, please write to info@moja.global.
+Before asking any questions, please have a look at our [FAQs](https://github.com/moja-global/.github/wiki). If your question isn't answered there, please write to info@moja.global.
 
-If your question concerns the code of a project, then please create a [new issue] in the relevant repository.
+If your question concerns the code of a project, then you should create a [new issue] in the relevant project's repository.
 
-You're also invited to [join moja global](Contributing/How-to-Join-moja-global.md) and ask your question(s) in the relevant channel of our private [Slack workspace](https://mojaglobal.slack.com/).
+You can also [join moja global](Contributing/How-to-Join-moja-global.md) and then ask your question(s) in the relevant channel of our private [Slack workspace](https://mojaglobal.slack.com/).
 
 
 ## How To Get Credit for Your Contribution?
 
 We use the [All Contributors Bot](https://allcontributors.org/) to recognize contributors.
 
-To get recognized, just add the following sentence in a comment after making your contribution (like submitting a pull request, replying to a question, resolving an issue, etc.):
+To get recognized, just add the following line to a comment after making your contribution (like submitting a pull request, replying to a question, resolving an issue, etc.):
 
 ```
 @all-contributors please add <@username> for <contributions>
@@ -38,11 +38,11 @@ After that, the @all-contributors bot will submit a PR to include you in the lis
 
 Bug fixes, performance improvements, code formatting, ...
 There are a lot ways in which you can contribute code!
-Please go thorugh the issues of our projects to find an issue that you can help us with.
-
-After that, go through our [coding guidelines](Governance/Coding-Guidelines.md) and [contribution criteria](Governance/Contribution-Criteria.md) before making any contributions.
+The issues list of a project is a great place to find something that you can help us with.
 
 To increase the chances of your code getting merged, please ensure that:
+* You satisfy our [contribution criteria](Governance/Contribution-Criteria.md).
+* Your code follows our [coding guidelines](Governance/Coding-Guidelines.md).
 * Your submission follows [Vincent Driessen's Git Branching](https://nvie.com/posts/a-successful-git-branching-model/) System.
 * Your code's documentation follows our [rules](Contributing/How-to-Document-Your-Contribution.md).
 * Your pull request:
@@ -62,32 +62,30 @@ This shows that you agree to the [Developer Certificate of Origin (DCO)](https:/
 
 We welcome all kinds of bug reports, user feedback and feature requests!
 
-We have created some issue templates to assist you in this. Please use these templates and create [a new issue](https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue) in the relevant project's repository.
+We've created some issue templates to assist you in this. Please use them to create [a new issue](https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue) in the relevant project's repository.
 
 
 ## How to Review & Contribute Science Design?
 
-Most of our code is informed by an underlying Science Design. We develop these designs collaboratively, so your contributions are most welcome!
+Most of our code is informed by an underlying Science Design. We develop these designs collaboratively and your contributions are most welcome!
 
 Every science-based project contains Science Designs under a directory named **Science**. There you can find:
 * PDFs that contain completed Science Designs.
-* Markdown (or `.md`) files that contain link to a Science Design document that is under development.
+* Markdown (or `.md`) files that contain link to a Science Design document that is still under development.
 
 For instructions on how to contribute Science Designs, please read [this](Contributing/How-to-Contribute-Review-Science-Design.md) document.
-
-You should read the Science Design documents of a project, before contributing to it.
 
 
 ## How to Suggest UI/UX Improvements?
 
 One of the most important areas of improvement to our flagship software FLINT is the user interface. We really need your help with this!
 
-If you have ideas on how we can imporove, please share them with us by creating a [new issue]. We could then [start a new project](Contributing/How-to-Start-a-New-Project.md) for your idea!
+If you have ideas on how we can improve, please share them with us by creating a [new issue]. We could then [start a new project](Contributing/How-to-Start-a-New-Project.md) for your idea!
 
 
 ## How to Contribute Translations?
 
-Right now our interfaces do not support translations and we also don't have a translation strategy in place. But we want to reach everyone, including those who do not speak English well. If you have any ideas in this regard then please share them with us by creating a [new issue].
+Right now our interfaces do not support translations and we also don't have a translation strategy in place. But we want to change this. We want our projects to be accessible to non-English speakers. If you have any ideas then please share them with us by creating a [new issue].
 
 
 ## Are There Other Ways of Contributing?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ moja global and everyone participating in it is governed by the Contributor Cove
 
 ### FAQ and Other Questions
 
-* You can find FAQs on the [Wiki](https://github.com/moja.global/.github/wiki).
+* You can find FAQs on the [Wiki](https://github.com/moja-global/.github/wiki).
 * If you have a question about the code, submit [user feedback](Contributing/How-to-Provide-User-Feedback.md) in the relevant repository
 * If you have a general question about a project or repository or moja global, [join moja global](Contributing/How-to-Join-moja-global.md) and
     * [submit a discussion](https://help.github.com/en/articles/about-team-discussions) to the project, repository or moja global [team](https://github.com/orgs/moja-global/teams)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,4 +100,4 @@ You can [coach new contributors](Contributing/How-to-Coach-New-Contributors.md),
 
 If there's some other way, not listed above, in which you'd like to help, then please drop us a line at info@moja.global. We'll get in touch with you!
 
-[new issue]: https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue
+[new issue]: https://github.com/moja-global/About_moja_global/issues/new/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,13 @@
 # moja global Contribution Guideline
 
-Thank you for helping. This is really great!
+We're very glad that you're thinking about contributing to moja global. We welcome all contributions!
 
-Follow these steps to [Get Credit for Your Contribution](Contributing/How-to-Get-Credit-for-Your-Contribution.md)
+Following are some general guidelines and instructions to assist you in contributing to our projects.
 
 
 ## Code of Conduct
-moja global and everyone participating in it is governed by the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
 
-
-## FAQ and Other Questions
-
-* You can find FAQs on the [Wiki](https://github.com/moja-global/.github/wiki).
-* If you have a question about the code, submit [user feedback](Contributing/How-to-Provide-User-Feedback.md) in the relevant repository
-* If you have a general question about a project or repository or moja global, [join moja global](Contributing/How-to-Join-moja-global.md) and
-    * [submit a discussion](https://help.github.com/en/articles/about-team-discussions) to the project, repository or moja global [team](https://github.com/orgs/moja-global/teams)
-    * [submit a message](https://get.slack.help/hc/en-us/categories/200111606#send-messages) to the relevant channel on [moja global's Slack workspace](mojaglobal.slack.com).
-* If you have other questions, please write to info@moja.global
-
-
+moja global and everyone participating in it are governed by the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
 
 ## How to Contribute
 Please write to info@moja.global if you would like to join a repo, the organisation on GitHub or the moja global SLACK workspace.
@@ -47,3 +36,13 @@ Click a link below to get started!
 *   [Fundraising](Contributing/How-to-Assist-with-Fundraising.md)
 *   [Strategy Advice](Contributing/How-to-Provide-Strategic-Advice.md)
 *   [Join the Board](Contributing/How-to-Join-the-Strategy-Board.md)
+
+## FAQ and General Questions
+
+If you have any questions then please start by going through our [FAQs](https://github.com/moja-global/.github/wiki). If your question is not answered there, please write to info@moja.global.
+
+If your question is related to the code of a project, then please create a [new issue] in the relevant repository.
+
+You're also invited to [join moja global](Contributing/How-to-Join-moja-global.md) and ask your question(s) in the relevant channel of our private [Slack workspace](https://mojaglobal.slack.com/).
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,33 +9,6 @@ Following are some general guidelines and instructions to assist you in contribu
 
 moja global and everyone participating in it are governed by the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
 
-## How to Contribute
-Please write to info@moja.global if you would like to join a repo, the organisation on GitHub or the moja global SLACK workspace.
-
-Click a link below to get started!
-
-
-
-*   [Bug reports and fixes](Contributing/How-to-Report-Bugs.md)
-*   [User Feedback](Contributing/How-to-Provide-User-Feedback.md)
-*   [Request Features](Contributing/How-to-Request-a-New-Feature.md)
-*   [Science Contribution and Review](Contributing/How-to-Contribute-Review-Science-Design.md)
-*   [Code](Contributing/How-to-Contribute-Code.md)
-*   Develop Tests, Review Code
-*   [User Experience Interface](Contributing/How-to-Improve-the-User-Interface.md)
-*   [Start a Project](Contributing/How-to-Start-a-New-Project.md)
-*   [Documentation](Contributing/How-to-Document-Your-Contribution.md)
-*   [Translations](Contributing/How-to-Provide-Translations.md)
-*   [Coach or teach](Contributing/How-to-Coach-New-Contributors.md)
-*   [Answer User Questions](Contributing/How-to-Answer-User-Questions.md)
-*   [Organise events](Contributing/How-to-Organise-Events.md)
-*   [Communication, Outreach](Contributing/How-to-Assist-with-Comms.md)
-*   [Website Development](Contributing/How-to-Improve-the-Website.md)
-*   [Administration](Contributing/How-to-Assist-with-Admin.md)
-*   Development Operations
-*   [Fundraising](Contributing/How-to-Assist-with-Fundraising.md)
-*   [Strategy Advice](Contributing/How-to-Provide-Strategic-Advice.md)
-*   [Join the Board](Contributing/How-to-Join-the-Strategy-Board.md)
 
 ## FAQ and General Questions
 
@@ -46,3 +19,85 @@ If your question is related to the code of a project, then please create a [new 
 You're also invited to [join moja global](Contributing/How-to-Join-moja-global.md) and ask your question(s) in the relevant channel of our private [Slack workspace](https://mojaglobal.slack.com/).
 
 
+## How To Get Credit for Your Contribution?
+
+We use the [All Contributors Bot](https://allcontributors.org/) to recognize contributors.
+
+To get recognized, just add the following sentence in a comment after making your contribution (like submitting a pull request, replying to a question, resolving an issue, etc.):
+
+```
+@all-contributors please add <@username> for <contributions>
+```
+
+Here `<@username>` is your GitHub username and `<contributions>` can be any word from [this list](https://allcontributors.org/docs/en/emoji-key) but the bot can use [basic Natural Language Parsing](https://github.com/all-contributors/all-contributors-bot/blob/master/src/tasks/processIssueComment/utils/parse-comment/index.js) to determine your contribution intent.
+
+After that, the @all-contributors bot will submit a PR to include `<@username>` in the list of contributors. Once this PR is accepted, you'll be added to the list of contributors in the relevant project's `README`.
+
+
+## How to Contribute Code?
+
+Bug fixes, performance improvements, formatting style -- there are a lot ways in which you can contribute code! Please have look at the issues list of our projects to find an issue that you can help us with.
+
+After that, go through our [coding guidelines](Governance/Coding-Guidelines.md) and [contribution criteria](Governance/Contribution-Criteria.md) before making any contributions.
+
+To increase the chances of your code getting merged, please ensure that:
+* Your submission follows [Vincent Driessen's Git Branching](https://nvie.com/posts/a-successful-git-branching-model/) System.
+* Your code is documented according to our [documentation rules](Contributing/How-to-Document-Your-Contribution.md).
+* Your pull request:
+    * passes all checks and has no conflicts.
+    * has a well-written title and message that clearly describes your proposed changes.
+
+Lasly, make sure that the commits in your pull requests are signed with the line
+
+```
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+This shows that you agree to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) and thus certifies that you wrote (or otherwise have the right to submit) your contribution to the project.
+
+
+## How to Report Bugs, Provide Feedback or Request Features?
+
+To submit bug reports, provide feedback or to request new features, please [create a new issue] in the repository of the relevant project.
+
+
+## How to Review & Contribute Science Design?
+
+Most of our code is informed by an underlying Science Design. We develop these designs collaboratively and we welcome all contributions!
+
+Science Design documents can be found in a directory named **Science** at the root of a relevant project's repository.
+
+There can be two types of Science Design files:
+* PDFs that contain completed Science Designs.
+* Markdown (or `.md`) files that contain link to a Science Design document that is under development.
+
+If you're planning on contributing to a project then please make sure to go through its completed Science Design documents.
+
+For instructions on how to contribute Science Designs, please read [this](Contributing/How-to-Contribute-Review-Science-Design.md) document.
+
+
+## How to Suggest UI/UX Improvements?
+
+One of the most important areas of improvement to our flagship software FLINT is the user interface. We really need your help here!
+
+If you have and idea on how we can imporove then please share it with us by creating a [new issue]. We can then [start a new project](Contributing/How-to-Start-a-New-Project.md) for your idea!
+
+
+## How to Contribute Translations?
+
+Right now our interfaces do not support translations and we also don't have a translation strategy in place.
+
+But we want to reach as many people as possible, including those who do not speak English well.
+
+So, if you any idea then please advise us on how we can facilitate contributions from those who are not comfortable in English. You can share your ideas by creating a [new issue].
+
+
+## Are There Other Ways of Contributing?
+
+Yes, there are many other ways in which you can help us!
+
+You can [coach new contributors](Contributing/How-to-Coach-New-Contributors.md), [answer user questions](Contributing/How-to-Answer-User-Questions.md), [organize events](Contributing/How-to-Organise-Events.md), help us in [administration](Contributing/How-to-Assist-with-Admin.md), [fundraising](Contributing/How-to-Assist-with-Fundraising.md), [website development](Contributing/How-to-Improve-the-Website.md), [communication/outreach](Contributing/How-to-Assist-with-Comms.md). You can also offer [strategy advice](Contributing/How-to-Provide-Strategic-Advice.md). You can even [join our strategy board](Contributing/How-to-Join-the-Strategy-Board.md)!
+
+If there's some other way, not listed above, in which you'd like to help, then please drop us a line at info@moja.global. We'll get in touch with you!
+
+[new issue]: https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
-## moja global Contribution Guideline
+# moja global Contribution Guideline
 
 Thank you for helping. This is really great!
 
 Follow these steps to [Get Credit for Your Contribution](Contributing/How-to-Get-Credit-for-Your-Contribution.md)
 
 
-### Code of Conduct
+## Code of Conduct
 moja global and everyone participating in it is governed by the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
 
 
-### FAQ and Other Questions
+## FAQ and Other Questions
 
 * You can find FAQs on the [Wiki](https://github.com/moja-global/.github/wiki).
 * If you have a question about the code, submit [user feedback](Contributing/How-to-Provide-User-Feedback.md) in the relevant repository
@@ -20,7 +20,7 @@ moja global and everyone participating in it is governed by the Contributor Cove
 
 
 
-### How to Contribute
+## How to Contribute
 Please write to info@moja.global if you would like to join a repo, the organisation on GitHub or the moja global SLACK workspace.
 
 Click a link below to get started!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,20 @@
 # moja global Contribution Guideline
 
-We're very glad that you're thinking about contributing to moja global. We welcome all contributions!
+We're so glad that you're thinking about contributing to moja global. We welcome your contributions!
 
-Following are some general guidelines and instructions to assist you in contributing to our projects.
+Following are some guidelines and instructions to assist you in contributing to our projects.
 
 
 ## Code of Conduct
 
-moja global and everyone participating in it are governed by the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
+moja global governs its participants according to the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). As a contributor, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
 
 
 ## FAQ and General Questions
 
 If you have any questions then please start by going through our [FAQs](https://github.com/moja-global/.github/wiki). If your question is not answered there, please write to info@moja.global.
 
-If your question is related to the code of a project, then please create a [new issue] in the relevant repository.
+If your question concerns the code of a project, then please create a [new issue] in the relevant repository.
 
 You're also invited to [join moja global](Contributing/How-to-Join-moja-global.md) and ask your question(s) in the relevant channel of our private [Slack workspace](https://mojaglobal.slack.com/).
 
@@ -29,72 +29,70 @@ To get recognized, just add the following sentence in a comment after making you
 @all-contributors please add <@username> for <contributions>
 ```
 
-Here `<@username>` is your GitHub username and `<contributions>` can be any word from [this list](https://allcontributors.org/docs/en/emoji-key) but the bot can use [basic Natural Language Parsing](https://github.com/all-contributors/all-contributors-bot/blob/master/src/tasks/processIssueComment/utils/parse-comment/index.js) to determine your contribution intent.
+Replace `<@username>` with your GitHub username and `<contributions>` with any word from [this list](https://allcontributors.org/docs/en/emoji-key).
 
-After that, the @all-contributors bot will submit a PR to include `<@username>` in the list of contributors. Once this PR is accepted, you'll be added to the list of contributors in the relevant project's `README`.
+After that, the @all-contributors bot will submit a PR to include you in the list of contributors. Once this PR gets accepted, you'll get added to the Contributors table in the relevant project's `README`.
 
 
 ## How to Contribute Code?
 
-Bug fixes, performance improvements, formatting style -- there are a lot ways in which you can contribute code! Please have look at the issues list of our projects to find an issue that you can help us with.
+Bug fixes, performance improvements, code formatting, ...
+There are a lot ways in which you can contribute code!
+Please go thorugh the issues of our projects to find an issue that you can help us with.
 
 After that, go through our [coding guidelines](Governance/Coding-Guidelines.md) and [contribution criteria](Governance/Contribution-Criteria.md) before making any contributions.
 
 To increase the chances of your code getting merged, please ensure that:
 * Your submission follows [Vincent Driessen's Git Branching](https://nvie.com/posts/a-successful-git-branching-model/) System.
-* Your code is documented according to our [documentation rules](Contributing/How-to-Document-Your-Contribution.md).
+* Your code's documentation follows our [rules](Contributing/How-to-Document-Your-Contribution.md).
 * Your pull request:
-    * passes all checks and has no conflicts.
-    * has a well-written title and message that clearly describes your proposed changes.
+    * Passes all checks and has no conflicts.
+    * Has a well-written title and message that briefly explains your proposed changes.
 
-Lasly, make sure that the commits in your pull requests are signed with the line
+Lastly, sign all your commits with a line like this:
 
 ```
 Signed-off-by: Random J Developer <random@developer.example.org>
 ```
 
-This shows that you agree to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) and thus certifies that you wrote (or otherwise have the right to submit) your contribution to the project.
+This shows that you agree to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). It certifies that you wrote (or otherwise have the right to submit) your contribution to the project.
 
 
 ## How to Report Bugs, Provide Feedback or Request Features?
 
-To submit bug reports, provide feedback or to request new features, please create [a new issue] in the repository of the relevant project.
+We welcome all kinds of bug reports, user feedback and feature requests!
+
+We have created some issue templates to assist you in this. Please use these templates and create [a new issue](https://help.github.com/en/github/managing-your-work-on-github/creating-an-issue) in the relevant project's repository.
 
 
 ## How to Review & Contribute Science Design?
 
-Most of our code is informed by an underlying Science Design. We develop these designs collaboratively and we welcome all contributions!
+Most of our code is informed by an underlying Science Design. We develop these designs collaboratively, so your contributions are most welcome!
 
-Science Design documents can be found in a directory named **Science** at the root of a relevant project's repository.
-
-There can be two types of Science Design files:
+Every science-based project contains Science Designs under a directory named **Science**. There you can find:
 * PDFs that contain completed Science Designs.
 * Markdown (or `.md`) files that contain link to a Science Design document that is under development.
 
-If you're planning on contributing to a project then please make sure to go through its completed Science Design documents.
-
 For instructions on how to contribute Science Designs, please read [this](Contributing/How-to-Contribute-Review-Science-Design.md) document.
+
+You should read the Science Design documents of a project, before contributing to it.
 
 
 ## How to Suggest UI/UX Improvements?
 
-One of the most important areas of improvement to our flagship software FLINT is the user interface. We really need your help here!
+One of the most important areas of improvement to our flagship software FLINT is the user interface. We really need your help with this!
 
-If you have and idea on how we can imporove then please share it with us by creating a [new issue]. We can then [start a new project](Contributing/How-to-Start-a-New-Project.md) for your idea!
+If you have ideas on how we can imporove, please share them with us by creating a [new issue]. We could then [start a new project](Contributing/How-to-Start-a-New-Project.md) for your idea!
 
 
 ## How to Contribute Translations?
 
-Right now our interfaces do not support translations and we also don't have a translation strategy in place.
-
-But we want to reach as many people as possible, including those who do not speak English well.
-
-So, if you any idea then please advise us on how we can facilitate contributions from those who are not comfortable in English. You can share your ideas by creating a [new issue].
+Right now our interfaces do not support translations and we also don't have a translation strategy in place. But we want to reach everyone, including those who do not speak English well. If you have any ideas in this regard then please share them with us by creating a [new issue].
 
 
 ## Are There Other Ways of Contributing?
 
-Yes, there are many other ways in which you can help us!
+Yes, there are a lot of other ways in which you can help us!
 
 You can [coach new contributors](Contributing/How-to-Coach-New-Contributors.md), [answer user questions](Contributing/How-to-Answer-User-Questions.md), [organize events](Contributing/How-to-Organise-Events.md), help us in [administration](Contributing/How-to-Assist-with-Admin.md), [fundraising](Contributing/How-to-Assist-with-Fundraising.md), [website development](Contributing/How-to-Improve-the-Website.md), [communication/outreach](Contributing/How-to-Assist-with-Comms.md). You can also offer [strategy advice](Contributing/How-to-Provide-Strategic-Advice.md). You can even [join our strategy board](Contributing/How-to-Join-the-Strategy-Board.md)!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,18 @@
 
 Thank you for helping. This is really great!
 
-Follow these steps to [Get Credit for Your Contribution](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Get-Credit-for-Your-Contribution.md)
+Follow these steps to [Get Credit for Your Contribution](Contributing/How-to-Get-Credit-for-Your-Contribution.md)
 
 
 ### Code of Conduct
-moja global and everyone participating in it is governed by the Contributor Covenant [Code of Conduct](https://github.com/moja-global/.github/blob/master/CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
+moja global and everyone participating in it is governed by the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
 
 
 ### FAQ and Other Questions
 
 * You can find FAQs on the [Wiki](https://github.com/moja.global/.github/wiki).
-* If you have a question about the code, submit [user feedback](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Provide-User-Feedback.md) in the relevant repository
-* If you have a general question about a project or repository or moja global, [join moja global](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Join-moja-global.md) and
+* If you have a question about the code, submit [user feedback](Contributing/How-to-Provide-User-Feedback.md) in the relevant repository
+* If you have a general question about a project or repository or moja global, [join moja global](Contributing/How-to-Join-moja-global.md) and
     * [submit a discussion](https://help.github.com/en/articles/about-team-discussions) to the project, repository or moja global [team](https://github.com/orgs/moja-global/teams)
     * [submit a message](https://get.slack.help/hc/en-us/categories/200111606#send-messages) to the relevant channel on [moja global's Slack workspace](mojaglobal.slack.com).
 * If you have other questions, please write to info@moja.global
@@ -27,23 +27,23 @@ Click a link below to get started!
 
 
 
-*   [Bug reports and fixes](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Report-Bugs.md)
-*   [User Feedback](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Provide-User-Feedback.md)
-*   [Request Features](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Request-a-New-Feature.md)
-*   [Science Contribution and Review](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Contribute-Review-Science-Design.md)
-*   [Code](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Contribute-Code.md)
+*   [Bug reports and fixes](Contributing/How-to-Report-Bugs.md)
+*   [User Feedback](Contributing/How-to-Provide-User-Feedback.md)
+*   [Request Features](Contributing/How-to-Request-a-New-Feature.md)
+*   [Science Contribution and Review](Contributing/How-to-Contribute-Review-Science-Design.md)
+*   [Code](Contributing/How-to-Contribute-Code.md)
 *   Develop Tests, Review Code
-*   [User Experience Interface](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Improve-the-User-Interface.md)
-*   [Start a Project](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Start-a-New-Project.md)
-*   [Documentation](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Document-Your-Contribution.md)
-*   [Translations](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Provide-Translations.md)
-*   [Coach or teach](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Coach-New-Contributors.md)
-*   [Answer User Questions](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Answer-User-Questions.md)
-*   [Organise events](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Organise-Events.md)
-*   [Communication, Outreach](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Assist-with-Comms.md)
-*   [Website Development](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Improve-the-Website.md)
-*   [Administration](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Assist-with-Admin.md)
+*   [User Experience Interface](Contributing/How-to-Improve-the-User-Interface.md)
+*   [Start a Project](Contributing/How-to-Start-a-New-Project.md)
+*   [Documentation](Contributing/How-to-Document-Your-Contribution.md)
+*   [Translations](Contributing/How-to-Provide-Translations.md)
+*   [Coach or teach](Contributing/How-to-Coach-New-Contributors.md)
+*   [Answer User Questions](Contributing/How-to-Answer-User-Questions.md)
+*   [Organise events](Contributing/How-to-Organise-Events.md)
+*   [Communication, Outreach](Contributing/How-to-Assist-with-Comms.md)
+*   [Website Development](Contributing/How-to-Improve-the-Website.md)
+*   [Administration](Contributing/How-to-Assist-with-Admin.md)
 *   Development Operations
-*   [Fundraising](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Assist-with-Fundraising.md)
-*   [Strategy Advice](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Provide-Strategic-Advice.md)
-*   [Join the Board](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Join-the-Strategy-Board.md)
+*   [Fundraising](Contributing/How-to-Assist-with-Fundraising.md)
+*   [Strategy Advice](Contributing/How-to-Provide-Strategic-Advice.md)
+*   [Join the Board](Contributing/How-to-Join-the-Strategy-Board.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,28 @@
 ## moja global Contribution Guideline
 
-Thank you for helping. This is really great!    
+Thank you for helping. This is really great!
 
 Follow these steps to [Get Credit for Your Contribution](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Get-Credit-for-Your-Contribution.md)
 
 
 ### Code of Conduct
-moja global and everyone participating in it is governed by the Contributor Covenant [Code of Conduct](https://github.com/moja-global/.github/blob/master/CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global. 
+moja global and everyone participating in it is governed by the Contributor Covenant [Code of Conduct](https://github.com/moja-global/.github/blob/master/CODE_OF_CONDUCT.md). By participating, you agree to uphold this code. Please report unacceptable behavior to info@moja.global. If you want your report to be handled confidentially, please report to guy@moja.global.
 
 
-### FAQ and Other Questions  
+### FAQ and Other Questions
 
-* You can find FAQs on the [Wiki](https://github.com/moja.global/.github/wiki).  
-* If you have a question about the code, submit [user feedback](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Provide-User-Feedback.md) in the relevant repository  
-* If you have a general question about a project or repository or moja global, [join moja global](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Join-moja-global.md) and 
+* You can find FAQs on the [Wiki](https://github.com/moja.global/.github/wiki).
+* If you have a question about the code, submit [user feedback](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Provide-User-Feedback.md) in the relevant repository
+* If you have a general question about a project or repository or moja global, [join moja global](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Join-moja-global.md) and
     * [submit a discussion](https://help.github.com/en/articles/about-team-discussions) to the project, repository or moja global [team](https://github.com/orgs/moja-global/teams)
-    * [submit a message](https://get.slack.help/hc/en-us/categories/200111606#send-messages) to the relevant channel on [moja global's Slack workspace](mojaglobal.slack.com). 
-* If you have other questions, please write to info@moja.global   
+    * [submit a message](https://get.slack.help/hc/en-us/categories/200111606#send-messages) to the relevant channel on [moja global's Slack workspace](mojaglobal.slack.com).
+* If you have other questions, please write to info@moja.global
 
 
 
 ### How to Contribute
-Please write to info@moja.global if you would like to join a repo, the organisation on GitHub or the moja global SLACK workspace.  
-  
+Please write to info@moja.global if you would like to join a repo, the organisation on GitHub or the moja global SLACK workspace.
+
 Click a link below to get started!
 
 
@@ -31,13 +31,13 @@ Click a link below to get started!
 *   [User Feedback](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Provide-User-Feedback.md)
 *   [Request Features](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Request-a-New-Feature.md)
 *   [Science Contribution and Review](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Contribute-Review-Science-Design.md)
-*   [Code](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Contribute-Code.md) 
+*   [Code](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Contribute-Code.md)
 *   Develop Tests, Review Code
 *   [User Experience Interface](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Improve-the-User-Interface.md)
 *   [Start a Project](https://github.com/moja-global/.github/blob/master/Contributing/How-to-Start-a-New-Project.md)
 *   [Documentation](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Document-Your-Contribution.md)
 *   [Translations](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Provide-Translations.md)
-*   [Coach or teach](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Coach-New-Contributors.md) 
+*   [Coach or teach](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Coach-New-Contributors.md)
 *   [Answer User Questions](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Answer-User-Questions.md)
 *   [Organise events](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Organise-Events.md)
 *   [Communication, Outreach](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Assist-with-Comms.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ This shows that you agree to the [Developer Certificate of Origin (DCO)](https:/
 
 ## How to Report Bugs, Provide Feedback or Request Features?
 
-To submit bug reports, provide feedback or to request new features, please [create a new issue] in the repository of the relevant project.
+To submit bug reports, provide feedback or to request new features, please create [a new issue] in the repository of the relevant project.
 
 
 ## How to Review & Contribute Science Design?


### PR DESCRIPTION
I've tried to inline all the essential articles (as mentions in #38). I've kept all the links to other non-essential documents by referencing them at appropriate places. 

The [Contribution Criteria](https://github.com/moja-global/About_moja_global/blob/master/Governance/Contribution-Criteria.md) document doesn't contain any content at the moment. It was referenced in the original, so I've also linked to it.

Apart from that, I've also:
* Removed trailing spaces.
* Replaced absolute links with relative links.
* Fixed a link.