### PR TITLE
Remove Git Branching Requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,6 @@ The issues list of a project is a great place to find something that you can hel
 To increase the chances of your code getting merged, please ensure that:
 * You satisfy our [contribution criteria](Governance/Contribution-Criteria.md).
 * Your code follows our [coding guidelines](Governance/Coding-Guidelines.md).
-* Your submission follows [Vincent Driessen's Git Branching](https://nvie.com/posts/a-successful-git-branching-model/) System.
 * Your code's documentation follows our [rules](Contributing/How-to-Document-Your-Contribution.md).
 * Your pull request:
     * Passes all checks and has no conflicts.

--- a/Contributing/How-to-Assign-a-Version.md
+++ b/Contributing/How-to-Assign-a-Version.md
@@ -1,28 +1,26 @@
 ## moja global Versioning
 
-Most moja global tools are platforms combined with modules. This results in many dependencies which in turn require tight version control without losing flexibility. 
+Most moja global tools are platforms combined with modules. This results in many dependencies which in turn require tight version control without losing flexibility.
 
-moja global projects use Vincent Driessen's [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) and therefore moja global uses the [related versioning system](https://datasift.github.io/gitflow/Versioning.html). More eleborate discussion can be found [in the on-line discussion of SemVer](https://github.com/semver/semver/issues/323).  
+The Standard Format for the version number consists of 3 indicators (MAJOR.MINOR.PATCH) and is only assigned at the moment the version is released. For work in progress a label is used as a placeholder.
 
-The Standard Format for the version number consists of 3 indicators (MAJOR.MINOR.PATCH) and is only assigned at the moment the version is released. For work in progress a label is used as a placeholder.  
-
-### Standard Format  
+### Standard Format
 
 The indicators in the version number will be changed as follows:
 
 MAJOR is increased when you:
 * Make backwards incompatible changes
-* Change the science design so a restructuring of the code or recoding the whole module is required  
+* Change the science design so a restructuring of the code or recoding the whole module is required
 
 MINOR is increased when you:
 * Make backward-compatible changes
-* Change the science design so code changes within the existing framework are required  
+* Change the science design so code changes within the existing framework are required
 
 PATCH is increased when you:
 * You make backwards-compatible bug fixes
 * Change the science design so no code changes are necessary
 
-### Build Versioning  
+### Build Versioning
 
 * Feature branches and the develop branch should always build snapshot versions including date (e.g. 2.6.0-SNAPSHOT201205012).
 * Release branches and hotfix branches should always build release candidate versions (e.g. 2.6.0-0.rc1).

--- a/Contributing/How-to-Contribute-Code.md
+++ b/Contributing/How-to-Contribute-Code.md
@@ -1,18 +1,15 @@
-## Code Contributions  
+## Code Contributions
 
-1. Get to know moja global (Thank you for doing this already! Otherwise you would not be here.)  
+1. Get to know moja global (Thank you for doing this already! Otherwise you would not be here.)
     * Read the [Contributing document](https://github.com/moja-global/About-moja-global/blob/master/CONTRIBUTING.md)
     * Read the [Code of Conduct](https://github.com/moja-global/.github/blob/master/CODE_OF_CONDUCT.md)
     * Review the [Coding Guidelines](https://github.com/moja-global/.github/blob/master/Governance/Coding-Guidelines.md) and the [Contribution Criteria](https://github.com/moja-global/.github/blob/master/Governance/Contribution-Criteria.md).
-    * Review the bug-list, open issues, Project Board (if you want to code a new feature) or the [Strategic Plan](https://github.com/moja-global/About-moja-global/blob/master/Governance/Strategic-Plan.md) (if you want to start a [new Project](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Start-a-New-Project.md).) 
-    * Contact the Code Coach if available in the README document or the Repo Maintainer by submitting an [Issue](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Provide-User-Feedback.md) with an @mention.  
+    * Review the bug-list, open issues, Project Board (if you want to code a new feature) or the [Strategic Plan](https://github.com/moja-global/About-moja-global/blob/master/Governance/Strategic-Plan.md) (if you want to start a [new Project](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Start-a-New-Project.md).)
+    * Contact the Code Coach if available in the README document or the Repo Maintainer by submitting an [Issue](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Provide-User-Feedback.md) with an @mention.
 
-1. [Join the moja global organisation](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Join-moja-global.md)  
+1. [Join the moja global organisation](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Join-moja-global.md)
 
-1. [Fork the repository](https://help.github.com/en/articles/fork-a-repo) if you do not want to join moja global or want to start working before your request to join has been approved.
-
-1. Follow [Vincent Driessen's Git Branching](https://nvie.com/posts/a-successful-git-branching-model/) System
-    * Name your Branch with same name using the Feature or Branch name with a [version number](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Assign-a-Version.md)
+1. [Fork the repository](https://help.github.com/en/articles/fork-a-repo).
 1. Make your contribution
     * Make changes or additions to the code
     * Follow [documentation rules](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Document-Your-Contribution.md)
@@ -24,4 +21,4 @@
     * Ensure your Pull-Request passes all checks and has no conflicts
     * Click `Create Pull Request`
 1. Get credit for your work
-    * [Claim credit](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Get-Credit-for-Your-Contribution.md) if you are not listed yet. 
+    * [Claim credit](https://github.com/moja-global/About-moja-global/blob/master/Contributing/How-to-Get-Credit-for-Your-Contribution.md) if you are not listed yet.


### PR DESCRIPTION
## Description

Vincent Driessen's Git Branching model (also known as [git-flow](https://nvie.com/posts/a-successful-git-branching-model/)) was proposed more than 10 years ago. It was meant for closed-source projects and wasn't really meant for open-source projects. Seeing that it is _required_ might confuse and deter new contributors.

Kindly consider removing this requirement.

## Type of change

- [X] This change requires a documentation update

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->