### PR TITLE
Adds Github Action on PR to catch broken links in .md files

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -1,0 +1,10 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -8,3 +8,5 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: '.github/workflows/markdown.links.config.json'

--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -1,0 +1,10 @@
+{
+    "ignorePatterns": [
+		{
+			"pattern": "linkedin.com"
+		},
+		{
+			"pattern": "slack.com"
+		}
+	]
+}


### PR DESCRIPTION
## Description

There are many broken links in this repo's markdown files. This github action identifies them and raises a flag on new PRs that introduce link breakage.

Fixes #148

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Running this locally on my fork, it's been successful at identify dozens of broken links. I will be using this actively in correcting broken links in a sister PR.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
(These changes are _intended_ to generate new warnings/CI failures. A sister PR corrects them.)
- [x] I have added tests that prove my fix is effective or that my feature works: 
unit tests aren't really appropriate here, but playtesting should give us a good sense of effectiveness.
- [x] New and existing unit tests pass locally with my changes
- [/] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.