### PR TITLE
Fix UI working group meeting notes

### DIFF
--- a/working-groups/user-interface/MeetingNotes.md
+++ b/working-groups/user-interface/MeetingNotes.md
@@ -1,0 +1,4 @@
+### Meeting notes
+
+- [19-2-22](MeetingNotes/19-2-22.md)
+- [26-2-22](MeetingNotes/26-2-22.md)

--- a/working-groups/user-interface/MeetingNotes/19-2-22.md
+++ b/working-groups/user-interface/MeetingNotes/19-2-22.md
@@ -1,6 +1,6 @@
-## Meeting notes - 19 - 02 - 22
+# 19-02-2022 UI Working Group weekly meeting 
 
-### Discussion
+## Discussion
 
 - A brief introduction to moja global and FLINT
 - Talked about what’s a working group and gave an introduction to the UI working group.
@@ -13,14 +13,14 @@
 - Roles one can have for the TSC working group notice board asre - content-writing/Documentation. Help impllemening the UI, Voulenteering to take the meeting notes, and other non code contributions
 
 
-### To Do (by 25th Feb)
+## New Action items
 
-- Look at other communities working group boards-
+- [ ] Look at other communities working group boards-
     - Rust - https://rust-lang.github.io/compiler-team/procedures/form-new-working-group/ 
     - Nodejs - https://github.com/nodejs/Release 
     - CNCF - https://www.cncf.io/certification/software-conformance/ 
     - (Other are welcome as well)
-- Put your findings under the discussion:
+- [ ] Put your findings under the discussion:
     - Discussion - https://github.com/moja-global/About_moja_global/discussions/157 
 - We’re working on this issue (If the link doesn’t work make use of the path.) https://github.com/moja-global/Google.Season.of.Documentation/issues/12 
 

--- a/working-groups/user-interface/MeetingNotes/26-2-22.md
+++ b/working-groups/user-interface/MeetingNotes/26-2-22.md
@@ -1,4 +1,4 @@
-# 02-26-2022 UI Working Group weekly meeting 
+# 26-02-2022 UI Working Group weekly meeting 
 
 ## Attendees
 - Aditya Tomar

--- a/working-groups/user-interface/MeetingNotes/MeetingNotes.md
+++ b/working-groups/user-interface/MeetingNotes/MeetingNotes.md
@@ -1,3 +1,0 @@
-### Meeting notes
-
-- [19-2-22](/MeetingNotes/MeetingNotes.md)


### PR DESCRIPTION
This PR attempts to fix the existing meeting notes for the UI working group.
Namely, it includes the following changes:
- Deleting the inner `MeetingNotes.md` inside the `MeetingNotes` directory. Let me know if this should be changed.
- Populating the `MeetingNotes.md` in the `user-interface` directory with correct links to the meeting notes. Any notes added further can be added as a link to this markdown.
- Change the headings in the notes from 19th Feb slightly so as to make them slightly consistent with the template we are following.
- Fix the date format on the 26th Feb header to DD-MM-YYYY.

Please let me know if there are any issues with this.