### PR TITLE
Add meeting notes template

### DIFF
--- a/working-groups/templates/MeetingNotes.md
+++ b/working-groups/templates/MeetingNotes.md
@@ -1,0 +1,20 @@
+# DD-MM-YYYY [working-group] Working Group weekly meeting 
+
+## Attendees
+List the attendees for the meeting
+
+## Agenda
+Pre-arranged stuff to talk about. 
+Email core team on Monday of the week of the dev meeting to ask for things to talk about.
+
+## Discussion
+Notes from todays dev meeting 
+
+## Check in on previous action items
+Copy previous action items from last meeting agenda.
+
+## New Action items
+Copy new action items to next meetings agenda so we can check in. 
+Make sure each action item is assigned to someone or it will likely not get done.
+
+[ ]  List resultant action items here


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds meeting notes template to the `working-groups` directory.

Fixes #161.

## Type of change

Please delete options that are not relevant.

- Adds a new markdown file.

## How Has This Been Tested?

N/A

## Checklist:
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->

I am currently adding the `MeetingNotes.md` template in a `templates` directory in the `working-groups` directory. If there are other templates that come up in the future, we can add all of them in the same directory? Wdyt?

Please let me know in case of any issues.

@chicken-biryani